### PR TITLE
Move action nubs

### DIFF
--- a/userstyle.css
+++ b/userstyle.css
@@ -65,8 +65,10 @@
 
 .inbox-message-list .inbox-message .message-actions {
   position:absolute !important;
-  top: 10px !important;
-  right: 5px !important;
+  left: 0px !important;
+  bottom: 0px !important;
+  top: auto !important;
+  right: auto !important;
   z-index: 1000 !important;
 }
 */

--- a/userstyle.css
+++ b/userstyle.css
@@ -75,7 +75,7 @@
   position:absolute !important;
   left: 0px !important;
   bottom: 0px !important;
-  top: auto !important;
+  top: 48px !important;
   right: auto !important;
   z-index: 1000 !important;
 }

--- a/userstyle.css
+++ b/userstyle.css
@@ -35,7 +35,7 @@
 }
 
 .inbox-message-list .inbox-message { 
-  padding: 6px 10px 6px 5px !important;
+  padding: 5px 0px !important;
 }
 .inbox-message-list .inbox-message .title { 
   font-size: 12px !important;

--- a/userstyle.css
+++ b/userstyle.css
@@ -13,6 +13,14 @@
 
 #chat li[class*='message'] { padding: 3px !important }
 
+#chat li[class*="message"] .message-author {
+  padding-left: 20px !important;
+}
+
+#chat li[class*="message"] .single-view-link {
+  padding-left:2px !important;
+}
+
 
 /* inbox */
 

--- a/userstyle.css
+++ b/userstyle.css
@@ -13,12 +13,14 @@
 
 #chat li[class*='message'] { padding: 3px !important }
 
-#chat li[class*="message"] .message-author {
-  padding-left: 20px !important;
-}
-
 #chat li[class*="message"] .single-view-link {
   padding-left:2px !important;
+}
+
+#chat .single-view-link.mini-icon {
+  position: relative !important;
+  float: left !important;
+  padding: 0px !important;
 }
 
 

--- a/userstyle.css
+++ b/userstyle.css
@@ -71,4 +71,12 @@
   right: auto !important;
   z-index: 1000 !important;
 }
+.inbox-message-list .inbox-message .message-actions button {
+  padding: 0px !important;
+}
+
+.dropdown-menu.pull-right, .pull-right.mentions-dropdown {
+  right: -180px !important;
+  top: 10px !important;
+}
 */

--- a/userstyle.css
+++ b/userstyle.css
@@ -87,4 +87,50 @@
   right: -180px !important;
   top: 10px !important;
 }
+
+/* View mailbox item */
+
+#single .single-view-close-button {
+  position: relative !important;
+  margin-top: 60px !important;
+  padding: 0px !important;
+  width: auto !important;
+  top: auto !important;
+  left: auto !important;
+}
+
+#single .single-view-close-button span {
+  position:relative !important;
+  top: auto !important;
+  left: auto !important;
+  width: auto !important;
+}
+
+#single .single-view-content {
+  left: 2em !important;
+  padding-right: 5px !important;
+  padding-top: 5px !important;
+}
+
+.single-message .single-message-actions {
+  position: relative !important;
+  top: auto !important;
+  left: auto !important;
+  right: auto !important;
+}
+
+.single-message .single-message-avatar {
+  margin: 0px 2px 0px 0px !important;
+  width: 3em !important;
+  height: 3em !important;
+}
+
+.single-message .single-message-header, .single-message .single-message-body {
+  margin-bottom: 5px !important;
+  padding-bottom: 5px !important;
+}
+
+.single-message .single-message-body table.headers{
+  margin: 5px 0px !important;
+}
 */

--- a/userstyle.css
+++ b/userstyle.css
@@ -26,6 +26,10 @@
 
 /* inbox */
 
+.inbox-panel, #chat, .flow {
+  float: right !important;
+}
+
 #avatar-list .user {
   margin-bottom: 0 !important;
   margin-right: 3px !important;


### PR DESCRIPTION
What this does:
- moves action nubs in the mailbox to below the icon
- moves the actions drop down tool tip to open to the left of the nub
- reduces spacing in mailbox a bit more

What needs to (maybe) be done:
- fix the little arrow on the action tooltips, it isn't lining up anymore

![screenshot_2013-07-06_10_23_pm](https://f.cloud.github.com/assets/441/757494/4ea601ec-e6ac-11e2-99da-eb3d9bbf86fd.png)

@redronin what do you think?
